### PR TITLE
Informativniji tweetovi

### DIFF
--- a/puobot.py
+++ b/puobot.py
@@ -74,7 +74,7 @@ def puoread(read_dir):
     """
     postojeci_postupci = []
     for filename in IMENA_POSTUPAKA:
-        with open(read_dir + filename + '.tsv', 'r') as f:
+        with open(read_dir + filename + '.tsv', 'r', encoding='utf-8') as f:
             in_file = f.read().splitlines()
         postojeci_postupci.append(in_file)
     return postojeci_postupci

--- a/puobot.py
+++ b/puobot.py
@@ -365,11 +365,11 @@ def trazi_razlike(staro, novo):
             kategorija = dijelovi[2]
             free_len = 140 - 3 - len(godina) - len(kategorija)- len(ime_file) - 25
             ime_zahvat = dijelovi[1][:free_len]
-            update = '-'.join([godina, ime_zahvat, kategorija, ime_file]) + ' ' + link
+            update = '|'.join([godina, ime_zahvat, kategorija, ime_file]) + ' ' + link
         elif len(dijelovi) == 3:
             free_len = 140 - 1 - len(ime_file) - 24
             ime_zahvat = dijelovi[0][:free_len]
-            update = ime_zahvat + '-' + ime_file + ' ' + link
+            update = ime_zahvat + '|' + ime_file + ' ' + link
         elif len(dijelovi) == 2:
             ime_zahvata = dijelovi[0][:110]
             update = ' '.join([ime_zahvata, link])

--- a/puobot.py
+++ b/puobot.py
@@ -349,6 +349,7 @@ def trazi_razlike(staro, novo):
         razlika = set(new) - set(old)
         razlike.extend(list(razlika))
 
+    POCETNI_ZNAKOVI = 60
     pattern = re.compile(r'^(.*?) \[PDF\]')
     novosti = []
     for razlika in razlike:
@@ -357,24 +358,40 @@ def trazi_razlike(staro, novo):
             ime_file = re.search(pattern, dijelovi[1]).group(1)
         else:
             ime_file = dijelovi[1]
-        ime_file = ime_file[:57] + '...'
         link = dijelovi[-1]
 
         if len(dijelovi) == 5:
             godina = dijelovi[0][-5:-1]
+            ime_zahvat = dijelovi[1]
             kategorija = dijelovi[2]
-            free_len = 140 - 3 - len(godina) - len(kategorija)- len(ime_file) - 25
-            ime_zahvat = dijelovi[1][:free_len]
-            update = '|'.join([godina, ime_zahvat, kategorija, ime_file]) + ' ' + link
+            free_len = 140 - 3 - len(godina) - len(kategorija) - 25
+
+            if ime_zahvat[:POCETNI_ZNAKOVI] == ime_file[:POCETNI_ZNAKOVI]:
+                ime_file = ime_file[:free_len]
+                update = '|'.join([godina, kategorija, ime_file])
+            else:
+                ime_file = ime_file[:POCETNI_ZNAKOVI] + '...'
+                free_len -= POCETNI_ZNAKOVI + 4
+                ime_zahvat = ime_zahvat[:free_len]
+                update = '|'.join([godina, ime_zahvat, kategorija, ime_file])
+
         elif len(dijelovi) == 3:
-            free_len = 140 - 1 - len(ime_file) - 24
-            ime_zahvat = dijelovi[0][:free_len]
-            update = ime_zahvat + '|' + ime_file + ' ' + link
+            ime_zahvat = dijelovi[0]
+            free_len = 140 - 1 - 25
+            if ime_zahvat[:POCETNI_ZNAKOVI] == ime_file[:POCETNI_ZNAKOVI]:
+                update = ime_file[:free_len]
+            else:
+                ime_file = ime_file[:POCETNI_ZNAKOVI] + '...'
+                free_len -= POCETNI_ZNAKOVI + 4
+                ime_zahvat = ime_zahvat[:free_len]
+                update = '|'.join([ime_zahvat, ime_file])
+
         elif len(dijelovi) == 2:
-            ime_zahvata = dijelovi[0][:110]
-            update = ' '.join([ime_zahvata, link])
+            ime_zahvat = dijelovi[0][:110]
+            update = ime_zahvat
+
+        update += ' ' + link
         print(update)
-        print(len(update))
         novosti.append(update)
     return novosti
 

--- a/puobot.py
+++ b/puobot.py
@@ -57,7 +57,7 @@ def puosave(save_dir, postupci):
         postupci (list): popis svih postupaka koje se snima.
     """
     for filename, postupak in zip(IMENA_POSTUPAKA, postupci):
-        with open(save_dir + filename + '.tsv', 'w') as f:
+        with open(save_dir + filename + '.tsv', 'w', encoding='utf-8') as f:
             f.write('\n'.join(postupak))
 
 


### PR DESCRIPTION
Drug(cij)i pokusaj rjesavanja #14, na sljedeci nacin:

* provjera jesu li puni naziv zahvata i puno ime dokumenti slicni/isti (podudaraju li se u pocetnih X znakova (trenutno postavljeno na 60 znakova))
* ako je doslo do podudarnosti - objavljuje se samo puno ime dokumenta - na raspolaganju je veci broj znakova
* ako nema podudarnosti - objavljuju se i naziv zahvata i ime dokumenta - isto kao i do sad

Mislim da ovo spaja zelje od @debeluziju sa upozorenjima od @mzec. Komentari?

Manje modifikacije:
* sada se polja odvajaju sa |, umjesto sa -. Meni djeluje preglednije/citljivije, ali to se lako vrati na staro.
* koristenje utf-8 encodinga kod snimanja/citanja .tsv formata - bez toga mi se ranije danas javila greska prilikom snimanja zbog slova đ u nekom od fajlova.